### PR TITLE
feature: extend serverless:exec to work for a simple (non cloud sql) Cloud Run app

### DIFF
--- a/google-serverless-exec.gemspec
+++ b/google-serverless-exec.gemspec
@@ -19,7 +19,7 @@ $LOAD_PATH.unshift lib unless $LOAD_PATH.include? lib
 require "google/serverless/exec/version"
 
 ::Gem::Specification.new do |spec|
-  spec.name = "google-severless-exec"
+  spec.name = "google-serverless-exec"
   spec.version = ::Google::Serverless::Exec::VERSION
   spec.authors = ["Daniel Azuma", "Tram Bui"]
   spec.email = ["dazuma@gmail.com", "trambui09098@gmail.com"]

--- a/lib/google/serverless/exec.rb
+++ b/lib/google/serverless/exec.rb
@@ -494,7 +494,7 @@ module Google
       # Executes the command synchronously. Streams the logs back to standard out
       # and does not return until the command has completed or timed out.
       #
-      def start
+      def start_app_engine
         resolve_parameters
         app_info = version_info @service, @version
         resolve_strategy app_info["env"]
@@ -546,7 +546,7 @@ module Google
       end
   
       def default_project
-        result = Util::Gcloud.execute \
+        result = Exec::Gcloud.execute \
           ["config", "get-value", "project"],
           capture: true, assert: false
         result.strip!
@@ -572,7 +572,7 @@ module Google
       # @return [String] Name of the most recent version.
       #
       def latest_version service
-        result = Util::Gcloud.execute \
+        result = Exec::Gcloud.execute \
           [
             "app", "versions", "list",
             "--project", @project,
@@ -602,7 +602,7 @@ module Google
       def version_info service, version
         service ||= "default"
         version ||= latest_version service
-        result = Util::Gcloud.execute \
+        result = Exec::Gcloud.execute \
           [
             "app", "versions", "describe", version,
             "--project", @project,
@@ -780,7 +780,7 @@ module Google
             "--timeout", @timeout
           ]
           execute_command.concat ["--gcs-log-dir", @gcs_log_dir] unless @gcs_log_dir.nil?
-          Util::Gcloud.execute execute_command
+          Exec::Gcloud.execute execute_command
         ensure
           file.close!
         end

--- a/lib/google/serverless/exec.rb
+++ b/lib/google/serverless/exec.rb
@@ -425,7 +425,7 @@ module Google
       #     when strategy is "cloud_build". (ex. "gs://BUCKET-NAME/FOLDER-NAME")
       # @param product [Symbol] The serverless product. If omitted, defaults to the
       #     value returns by {Google::Serverless::Exec.default_product}.
-      #     Allowed values are `APP_ENGINE` and `CLOUD_RUN`.
+      #     Allowed values are {APP_ENGINE} and {CLOUD_RUN}.
       #
       def initialize command,
                      project: nil, service: nil, config_path: nil, version: nil,
@@ -499,7 +499,7 @@ module Google
 
       ##
       # @return [Symbol] The serverless product to use.
-      #     Allowed values are `APP_ENGINE` and  `CLOUD_RUN`
+      #     Allowed values are {APP_ENGINE} and  {CLOUD_RUN}
       #
       attr_accessor :product
   

--- a/lib/google/serverless/exec.rb
+++ b/lib/google/serverless/exec.rb
@@ -813,9 +813,9 @@ module Google
           image = container ? container["image"] : image_from_build(app_info)
         else
           env_variables = {}
-          cloud_sql_instances = []
-          # TODO: get the cloud_sql_instance
-          image = app_info["spec"]["template"]["spec"]["containers"][0]["image"]
+          metadata_annotations = app_info["spec"]["template"]["metadata"]["annotations"]
+          cloud_sql_instances = metadata_annotations["run.googleapis.com/cloudsql-instances"] || []
+          image = metadata_annotations["client.knative.dev/user-image"]
         end
   
         describe_build_strategy

--- a/lib/google/serverless/exec/tasks.rb
+++ b/lib/google/serverless/exec/tasks.rb
@@ -272,21 +272,21 @@ module Google
           end
     
           def verify_gcloud_and_report_errors
-            Util::Gcloud.verify!
-          rescue Util::Gcloud::BinaryNotFound
+            Exec::Gcloud.verify!
+          rescue Exec::Gcloud::BinaryNotFound
             report_error <<~MESSAGE
               Could not find the `gcloud` binary in your system path.
               This tool requires the Google Cloud SDK. To download and install it,
               visit https://cloud.google.com/sdk/downloads
             MESSAGE
-          rescue Util::Gcloud::GcloudNotAuthenticated
+          rescue Exec::Gcloud::GcloudNotAuthenticated
             report_error <<~MESSAGE
               The gcloud authorization has not been completed. If you have not yet
               initialized the Google Cloud SDK, we recommend running the `gcloud init`
               command as described at https://cloud.google.com/sdk/docs/initializing
               Alternately, you may log in directly by running `gcloud auth login`.
             MESSAGE
-          rescue Util::Gcloud::ProjectNotSet
+          rescue Exec::Gcloud::ProjectNotSet
             report_error <<~MESSAGE
               The gcloud project configuration has not been set. If you have not yet
               initialized the Google Cloud SDK, we recommend running the `gcloud init`

--- a/lib/google/serverless/exec/tasks.rb
+++ b/lib/google/serverless/exec/tasks.rb
@@ -135,6 +135,8 @@ module Google
         WRAPPER_IMAGE_ENV = "GAE_EXEC_WRAPPER_IMAGE"
         ## @private
         GCS_LOG_DIR = "CLOUD_BUILD_GCS_LOG_DIR"
+        ## @private
+        PRODUCT_ENV = "PRODUCT"
     
         @defined = false
     
@@ -169,7 +171,8 @@ module Google
                                   timeout:       ::ENV[TIMEOUT_ENV],
                                   wrapper_image: ::ENV[WRAPPER_IMAGE_ENV],
                                   strategy:      ::ENV[STRATEGY_ENV],
-                                  gcs_log_dir:   ::ENV[GCS_LOG_DIR]
+                                  gcs_log_dir:   ::ENV[GCS_LOG_DIR],
+                                  product:       ::ENV[PRODUCT_ENV]
               start_and_report_errors app_exec
               exit
             end
@@ -297,7 +300,7 @@ module Google
           end
     
           def start_and_report_errors app_exec
-            app_exec.start
+            app_exec.product == "app_engine" ? app_exec.start_app_engine : app_exec.start_cloud_run
           rescue Exec::ConfigFileNotFound => e
             report_error <<~MESSAGE
               Could not determine which service should run this command because the App


### PR DESCRIPTION
In order to extend the serverless:exec gem to work on a basic sinatra Cloud Run app: 
- Added in a new `product` field to hold whether we're deploying an "app_engine" or "cloud_run" app. 
- Created a new `start_cloud_run` function to run the "cloud_build" strategy on the cloud run app
- Added in a new `default_product` function to autodetect whether we're running on "app_engine" or "cloud_run".
- Wrote a new `version_info_cloud_run` function to retrieve the cloud run metadata hash
- Edited the `start_build_strategy` to retrieve the cloud run image 

I think the `version_info_cloud_run` function could be refactored or combined with the old `version_info` function, but was unsure because we don't need the `version` field for Cloud Run.

