### PR TITLE
chore: retrieve env variables for cloud run app

### DIFF
--- a/lib/google/serverless/exec.rb
+++ b/lib/google/serverless/exec.rb
@@ -815,9 +815,7 @@ module Google
         else
           env_variables = {}
           app_env = app_info["spec"]["template"]["spec"]["containers"][0]["env"]
-          if app_env
-            app_env.each { |env| env_variables[env["name"]] = env["value"] }
-          end
+          app_env&.each { |env| env_variables[env["name"]] = env["value"] }
           metadata_annotations = app_info["spec"]["template"]["metadata"]["annotations"]
           cloud_sql_instances = metadata_annotations["run.googleapis.com/cloudsql-instances"] || []
           image = metadata_annotations["client.knative.dev/user-image"]

--- a/lib/google/serverless/exec.rb
+++ b/lib/google/serverless/exec.rb
@@ -376,7 +376,8 @@ module Google
         #     for App Engine Flexible and Cloud Run).
         # @param gcs_log_dir [String,nil] GCS bucket name of the cloud build log
         #     when strategy is "cloud_build". (ex. "gs://BUCKET-NAME/FOLDER-NAME")
-        #
+        # @param product [Symbol] The serverless product to use. If omitted, defaults to
+        #     the value returned by {Google::Serverless::Exec.default_product}
         def new_rake_task name, args: [], env_args: [],
                           service: nil, config_path: nil, version: nil,
                           timeout: nil, project: nil, wrapper_image: nil,
@@ -499,7 +500,7 @@ module Google
 
       ##
       # @return [Symbol] The serverless product to use.
-      #     Allowed values are {APP_ENGINE} and  {CLOUD_RUN}
+      #     Allowed values are {APP_ENGINE} and {CLOUD_RUN}
       #
       attr_accessor :product
   
@@ -802,7 +803,7 @@ module Google
   
       ##
       # @private
-      # Performs exec on a GAE flexible app.
+      # Performs exec on a GAE flexible and Cloud Run apps.
       #
       def start_build_strategy app_info
         if @product == APP_ENGINE
@@ -813,6 +814,7 @@ module Google
           image = container ? container["image"] : image_from_build(app_info)
         else
           env_variables = {}
+          app_info["spec"]["template"]["spec"]["containers"][0]["env"].each { |env| env_variables[env["name"]] = env["value"] }
           metadata_annotations = app_info["spec"]["template"]["metadata"]["annotations"]
           cloud_sql_instances = metadata_annotations["run.googleapis.com/cloudsql-instances"] || []
           image = metadata_annotations["client.knative.dev/user-image"]

--- a/lib/google/serverless/exec.rb
+++ b/lib/google/serverless/exec.rb
@@ -377,7 +377,7 @@ module Google
         # @param gcs_log_dir [String,nil] GCS bucket name of the cloud build log
         #     when strategy is "cloud_build". (ex. "gs://BUCKET-NAME/FOLDER-NAME")
         # @param product [Symbol] The serverless product to use. If omitted, defaults to
-        #     the value returned by {Google::Serverless::Exec.default_product}
+        #     the value returned by {Google::Serverless::Exec#default_product}
         def new_rake_task name, args: [], env_args: [],
                           service: nil, config_path: nil, version: nil,
                           timeout: nil, project: nil, wrapper_image: nil,
@@ -425,7 +425,7 @@ module Google
       # @param gcs_log_dir [String,nil] GCS bucket name of the cloud build log
       #     when strategy is "cloud_build". (ex. "gs://BUCKET-NAME/FOLDER-NAME")
       # @param product [Symbol] The serverless product. If omitted, defaults to the
-      #     value returns by {Google::Serverless::Exec.default_product}.
+      #     value returns by {Google::Serverless::Exec#default_product}.
       #     Allowed values are {APP_ENGINE} and {CLOUD_RUN}.
       #
       def initialize command,
@@ -814,7 +814,10 @@ module Google
           image = container ? container["image"] : image_from_build(app_info)
         else
           env_variables = {}
-          app_info["spec"]["template"]["spec"]["containers"][0]["env"].each { |env| env_variables[env["name"]] = env["value"] }
+          app_env = app_info["spec"]["template"]["spec"]["containers"][0]["env"]
+          if app_env
+            app_env.each { |env| env_variables[env["name"]] = env["value"] }
+          end
           metadata_annotations = app_info["spec"]["template"]["metadata"]["annotations"]
           cloud_sql_instances = metadata_annotations["run.googleapis.com/cloudsql-instances"] || []
           image = metadata_annotations["client.knative.dev/user-image"]

--- a/lib/google/serverless/exec/tasks.rb
+++ b/lib/google/serverless/exec/tasks.rb
@@ -281,8 +281,8 @@ module Google
                 GCS bucket name of the cloud build log when GAE_STRATEGY is "cloud_build".
                 (ex. "gs://BUCKET-NAME/FOLDER-NAME")
               PRODUCT
-                The serverless product to use. If not specified, autodetects which product,
-                {APP_ENGINE} or {CLOUD_RUN} to use.
+                The serverless product to use. Valid values are "app_engine" and "cloud_run".
+                If not specified, autodetects the serverless product to use.
               This rake task is provided by the "serverless" gem. To make these tasks
               available, add the following line to your Rakefile:
                   require "google/serverless/exec/tasks"

--- a/lib/google/serverless/exec/tasks.rb
+++ b/lib/google/serverless/exec/tasks.rb
@@ -280,9 +280,12 @@ module Google
               CLOUD_BUILD_GCS_LOG_DIR
                 GCS bucket name of the cloud build log when GAE_STRATEGY is "cloud_build".
                 (ex. "gs://BUCKET-NAME/FOLDER-NAME")
+              PRODUCT
+                The serverless product to use. If not specified, autodetects which product,
+                {APP_ENGINE} or {CLOUD_RUN} to use.
               This rake task is provided by the "serverless" gem. To make these tasks
               available, add the following line to your Rakefile:
-                  require "serverless/tasks"
+                  require "google/serverless/exec/tasks"
               If your app uses Ruby on Rails, the gem provides a railtie that adds its
               tasks automatically, so you don't have to do anything beyond adding the
               gem to your Gemfile.


### PR DESCRIPTION
Update `start_build_strategy` function to grab the environment variables from a Cloud Run app and pass them into the build process and added more documentation around the new `PRODUCT` field.