### PR TITLE
fix: Doesn't work on ruby 3.0+

### DIFF
--- a/google-serverless-exec.gemspec
+++ b/google-serverless-exec.gemspec
@@ -40,6 +40,8 @@ version = ::Google::Serverless::Exec::VERSION
   spec.required_ruby_version = ">= 2.5.0"
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "webrick"
+
   spec.add_development_dependency "google-style", "~> 1.25.1"
   spec.add_development_dependency "minitest", "~> 5.11"
   spec.add_development_dependency "minitest-focus", "~> 1.1"

--- a/lib/google/serverless/exec.rb
+++ b/lib/google/serverless/exec.rb
@@ -737,7 +737,7 @@ module Google
         yaml_data = {
           "runtime"        => app_info["runtime"],
           "service"        => @service,
-          "entrypoint"     => "ruby #{entrypoint_file}",
+          "entrypoint"     => "bundle exec ruby #{entrypoint_file}",
           "env_variables"  => app_info["envVariables"],
           "manual_scaling" => { "instances" => 1 }
         }


### PR DESCRIPTION
# Context
When I try to run this gem with Google App Engine (Standard Edition, Ruby 3.0), I get the following error.

## Error log
<details>
<summary>Client</summary>

```
$ bundle exec rake appengine:exec -- bundle exec rake db:migrate

(snip)

Deployed service [default] to [http://appengine-exec-20220917160435.myapp.an.r.appspot.com]

You can stream logs from the command line by running:
  $ gcloud app logs tail -s default

To view your application in the web browser run:
  $ gcloud app browse --project=myapp

---------- EXECUTE COMMAND ----------
COMMAND: ["bundle", "exec", "rake", "db:migrate"]

---------- CLEANUP ----------
Deleting the following versions:
 - myapp/default/appengine-exec-20220917160435
Deleting [default/appengine-exec-20220917160435]...
......done.
rake aborted!
JSON::ParserError: 859: unexpected token at '<html><head>
<meta http-equiv="content-type" content="text/html;charset=utf-8">
<title>500 Server Error</title>
</head>
<body text=#000000 bgcolor=#ffffff>
<h1>Error: Server Error</h1>
<h2>The server encountered an error and could not complete your request.<p>Please try again in 30 seconds.</h2>
<h2></h2>
</body></html>
'
/home/runner/work/myapp/myapp/vendor/bundle/ruby/3.0.0/gems/json-2.6.2/lib/json/common.rb:216:in `parse'
/home/runner/work/myapp/myapp/vendor/bundle/ruby/3.0.0/gems/json-2.6.2/lib/json/common.rb:216:in `parse'
/home/runner/work/myapp/myapp/vendor/bundle/ruby/3.0.0/gems/google-serverless-exec-0.2.0/lib/google/serverless/exec.rb:793:in `block (2 levels) in track_status'
/home/runner/work/myapp/myapp/vendor/bundle/ruby/3.0.0/gems/google-serverless-exec-0.2.0/lib/google/serverless/exec.rb:788:in `loop'
/home/runner/work/myapp/myapp/vendor/bundle/ruby/3.0.0/gems/google-serverless-exec-0.2.0/lib/google/serverless/exec.rb:788:in `block in track_status'
/home/runner/work/myapp/myapp/vendor/bundle/ruby/3.0.0/gems/google-serverless-exec-0.2.0/lib/google/serverless/exec.rb:785:in `track_status'
/home/runner/work/myapp/myapp/vendor/bundle/ruby/3.0.0/gems/google-serverless-exec-0.2.0/lib/google/serverless/exec.rb:699:in `start_deployment_strategy'
/home/runner/work/myapp/myapp/vendor/bundle/ruby/3.0.0/gems/google-serverless-exec-0.2.0/lib/google/serverless/exec.rb:543:in `start_app_engine'
/home/runner/work/myapp/myapp/vendor/bundle/ruby/3.0.0/gems/google-serverless-exec-0.2.0/lib/google/serverless/exec.rb:531:in `start'
/home/runner/work/myapp/myapp/vendor/bundle/ruby/3.0.0/gems/appengine-0.7.0/lib/appengine/tasks.rb:329:in `start_and_report_errors'
/home/runner/work/myapp/myapp/vendor/bundle/ruby/3.0.0/gems/appengine-0.7.0/lib/appengine/tasks.rb:172:in `block in setup_exec_task'
/home/runner/work/myapp/myapp/vendor/bundle/ruby/3.0.0/gems/sentry-ruby-5.4.2/lib/sentry/rake.rb:24:in `execute'
/home/runner/work/myapp/myapp/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/opt/hostedtoolcache/Ruby/3.0.4/x64/bin/bundle:23:in `load'
/opt/hostedtoolcache/Ruby/3.0.4/x64/bin/bundle:23:in `<main>'
Tasks: TOP => appengine:exec
(See full trace by running task with --trace)
Error: Process completed with exit code 1.
```
</details>


<details>
<summary>AppEngine (Cloud Logging)</summary>

```
<internal:/opt/ruby/lib/ruby/site_ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- webrick (LoadError)
 from <internal:/opt/ruby/lib/ruby/site_ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
 from appengine_exec_entrypoint_20220917171046.rb:15:in `<main>'
```
</details>


# Why
`webrick` is used following

https://github.com/GoogleCloudPlatform/serverless-exec-ruby/blob/google-serverless-exec/v0.2.0/data/exec_standard_entrypoint.rb.erb#L15

But `webrick` is removed from default gem since ruby 3.0.0

https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/

So I add this.