### PR TITLE
Support the latest version of gcloud-cli (ver. 473.0.0)

### DIFF
--- a/lib/google/serverless/exec.rb
+++ b/lib/google/serverless/exec.rb
@@ -828,7 +828,7 @@ module Google
           env_variables = app_info["envVariables"] || {}
           beta_settings = app_info["betaSettings"] || {}
           cloud_sql_instances = beta_settings["cloud_sql_instances"] || []
-          container = app_info["deployment"]["container"]
+          container = app_info.dig("deployment")&.dig("container")
           image = container ? container["image"] : image_from_build(app_info)
         else
           env_variables = {}


### PR DESCRIPTION
When I ran serverless-exec-ruby via appengine-ruby on gcloud-cli (ver. 473.0.0), I got the following error.
I thought it was due to a change in the command execution result, so I fixed it so that the error does not occur even if “deployment” is not specified.

```
$ bundle exec rake appengine:exec -- bundle exec rake db:migrate
rake aborted!
NoMethodError: undefined method `[]' for nil (NoMethodError)

          container = app_info["deployment"]["container"]
                                            ^^^^^^^^^^^^^
/usr/local/rvm/gems/default/gems/google-serverless-exec-0.2.0/lib/google/serverless/exec.rb:833:in `start_build_strategy'
/usr/local/rvm/gems/default/gems/google-serverless-exec-0.2.0/lib/google/serverless/exec.rb:541:in `start_app_engine'
/usr/local/rvm/gems/default/gems/google-serverless-exec-0.2.0/lib/google/serverless/exec.rb:531:in `start'
/usr/local/rvm/gems/default/gems/appengine-0.7.0/lib/appengine/tasks.rb:329:in `start_and_report_errors'
/usr/local/rvm/gems/default/gems/appengine-0.7.0/lib/appengine/tasks.rb:172:in `block in setup_exec_task'
/usr/local/rvm/gems/default/gems/rake-13.2.1/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:25:in `load'
/usr/local/bin/bundle:25:in `<main>'
Tasks: TOP => appengine:exec
(See full trace by running task with --trace)
```